### PR TITLE
Revert "LX-1447 Migrate dlcs-staff-ui to new test rancher"

### DIFF
--- a/apps/test/values.yaml
+++ b/apps/test/values.yaml
@@ -87,18 +87,14 @@ argocd_applications:
           ref: values
     - name: dlcs-staff-uitest
       deployment_namespace: dlcs-staff-uitest
-      namespace_team: systems
       project: default
-      destination: testrke01
+      destination: testsoftwaredev
       sources:
-        - repourl: https://chartmuseum.library.ucla.edu
-          chart: dlcs-staff-ui
-          revision: 0.8.0
-          valueFiles:
-            - $values/charts/test-dlcsstaffui-values.yaml
         - repourl: https://github.com/UCLALibrary/dlcs-staff-ui
-          revision: main
-          ref: values
+          path: charts
+          revision: HEAD
+          valueFiles:
+            - test-dlcsstaffui-values.yaml
     - name: lbstest
       deployment_namespace: lbstest
       namespace_team: systems


### PR DESCRIPTION
Revert these changes until CoreOps team can add VLAN to NFS share allow list. 