### PR TITLE
Remove the oral-history app

### DIFF
--- a/apps/systems-team-prod-environment-values.yaml
+++ b/apps/systems-team-prod-environment-values.yaml
@@ -234,38 +234,38 @@ applications:
         - PruneLast=true
     revisionHistoryLimit: 20
 # Oral History Public Web
-  - name: oral-history-public-web
-    namespace: argocd
-    finalizers:
-    - resources-finalizer.argocd.argoproj.io
-    additionalLabels: {}
-    additionalAnnotations:
-      notifications.argoproj.io/subscribe.on-sync-succeeded.slack: softwaredev-systems-firehose
-    project: default
-    sources:
-    - chart: oralhistory
-      repoURL: https://chartmuseum.library.ucla.edu
-      targetRevision: 0.0.4
-      helm:
-        valueFiles:
-        - $values/charts/prod-oralhistory-values.yaml
-    - ref: values
-      repoURL: https://github.com/UCLALibrary/oral-history
-      targetRevision: main
-    destination:
-      name: prodrke01
-      namespace: oralhistory
-    syncPolicy:
-      managedNamespaceMetadata:
-        labels:
-          namespace_team: systems
-      automated:
-        prune: true
-        selfHeal: true
-      syncOptions:
-        - CreateNamespace=true
-        - PruneLast=true
-    revisionHistoryLimit: 20
+##  - name: oral-history-public-web
+##    namespace: argocd
+##    finalizers:
+##    - resources-finalizer.argocd.argoproj.io
+##    additionalLabels: {}
+##    additionalAnnotations:
+##      notifications.argoproj.io/subscribe.on-sync-succeeded.slack: softwaredev-systems-firehose
+##    project: default
+##    sources:
+##    - chart: oralhistory
+##      repoURL: https://chartmuseum.library.ucla.edu
+##      targetRevision: 0.0.4
+##      helm:
+##        valueFiles:
+##        - $values/charts/prod-oralhistory-values.yaml
+##    - ref: values
+##      repoURL: https://github.com/UCLALibrary/oral-history
+##      targetRevision: main
+##    destination:
+##      name: prodrke01
+##      namespace: oralhistory
+##    syncPolicy:
+##      managedNamespaceMetadata:
+##        labels:
+##          namespace_team: systems
+##      automated:
+##        prune: true
+##        selfHeal: true
+##      syncOptions:
+##        - CreateNamespace=true
+##        - PruneLast=true
+##    revisionHistoryLimit: 20
 
 #
 #


### PR DESCRIPTION
Commentingout for ease of restoration (searching git for reverts isn't always the funnest)

Oral History Solr is using zookeeper, and we don't want that