### PR TITLE
SYS-1477: Add Link Shortener to Systems production environment

### DIFF
--- a/apps/systems-team-prod-environment-values.yaml
+++ b/apps/systems-team-prod-environment-values.yaml
@@ -233,7 +233,39 @@ applications:
         - CreateNamespace=true
         - PruneLast=true
     revisionHistoryLimit: 20
-
+# Link Shortener Application
+  - name: link-shortener
+    namespace: argocd
+    finalizers:
+    - resources-finalizer.argocd.argoproj.io
+    additionalLabels:
+      team: systems
+    additionalAnnotations: {}
+    project: default
+    sources:
+    - chart: link-shortener
+      repoURL: https://chartmuseum.library.ucla.edu
+      targetRevision: 1.0.0
+      helm:
+        valueFiles:
+        - $values/charts/prod-linkshortener-values.yaml
+    - ref: values
+      repoURL: https://github.com/UCLALibrary/link-shortener
+      targetRevision: main
+    destination:
+      name: prodrke01
+      namespace: link-shortenerprod
+    syncPolicy:
+      managedNamespaceMetadata:
+        labels:
+          namespace_team: systems
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+        - PruneLast=true
+    revisionHistoryLimit: 20
 #
 #
 # -- Deploy Argo CD Projects within this helm release


### PR DESCRIPTION
This PR adds the Systems team's Link Shortener application to the production environment for ArgoCD.

@cachemeoutside I believe I've set everything correctly, based on the other applications in this file.  The value of `sources/0/targetRevision` matches the `version` in the applications 'charts/Chart.yaml`.  If I missed anything, please let me know.

See also https://github.com/UCLALibrary/link-shortener/pull/4, which adds the chart itself to the application.  Since this PR references that chart, I suspect the application PR needs to be merged before this one.
