### PR TITLE
Enable Slack notifications for Oral History

### DIFF
--- a/apps/apps-team-prod-environment-values.yaml
+++ b/apps/apps-team-prod-environment-values.yaml
@@ -7,7 +7,8 @@ applications:
     namespace: argocd
     finalizers:
     - resources-finalizer.argocd.argoproj.io
-    additionalLabels: {}
+    additionalLabels:
+      team: ucla-scientist-oral-history
     additionalAnnotations: {}
     project: default
     sources:
@@ -40,7 +41,8 @@ applications:
     namespace: argocd
     finalizers:
     - resources-finalizer.argocd.argoproj.io
-    additionalLabels: {}
+    additionalLabels:
+      team: ucla-scientist-oral-history
     additionalAnnotations: {}
     project: default
     sources:

--- a/apps/apps-team-test-environment-values.yaml
+++ b/apps/apps-team-test-environment-values.yaml
@@ -7,7 +7,8 @@ applications:
     namespace: argocd
     finalizers:
     - resources-finalizer.argocd.argoproj.io
-    additionalLabels: {}
+    additionalLabels:
+      team: ucla-scientist-oral-history
     additionalAnnotations: {}
     project: default
     sources:

--- a/infrastructure/deployment/argocd.library.ucla.edu-values.yaml
+++ b/infrastructure/deployment/argocd.library.ucla.edu-values.yaml
@@ -3256,6 +3256,15 @@ notifications:
       - on-health-degraded
       - on-sync-failed
       - on-sync-succeeded
+    - recipients:
+      - slack:ucla-scientist-oral-history
+      selector: team=ucla-scientist-oral-history
+      triggers:
+      - on-deployed
+      - on-health-degraded
+      - on-sync-failed
+      - on-sync-succeeded
+
 
   # -- The notification template is used to generate the notification content
   ## For more information: https://argocd-notifications.readthedocs.io/en/stable/templates/


### PR DESCRIPTION
Notify Slack when:
- deployed
- health check fails
- sync fails
- sync succeeds

JIRA: LX-1612 / Enable Oral History app ArgoCD Sync Notifications in Scientist
                Slack Channel