### PR TITLE
Fix BUCKETEER_IIIF_URL formatting

### DIFF
--- a/apps/services-team-value-files/test-bucketeer.yaml
+++ b/apps/services-team-value-files/test-bucketeer.yaml
@@ -182,7 +182,7 @@ configmap:
     BUCKETEER_FS_IMAGE_PREFIX: "UCLAFilePathPrefix"
     BUCKETEER_SLACK_ERROR_CHANNEL_ID: "dev-null"
     BUCKETEER_SLACK_CHANNEL_ID: "dev-null"
-    BUCKETEER_IIIF_URL: "https://test-iiif.library.ucla.edu"
+    BUCKETEER_IIIF_URL: "https://test.iiif.library.ucla.edu"
     BUCKETEER_IIIF_URL_PREFIX: "/iiif/2/"
     HEAP_SIZE: "2g"
     SOURCE_MAX_FILE_SIZE: "350000000"


### PR DESCRIPTION
Thinking test-iiif which was the previous value in the helm values file had changed to test.iiif at some point and was never updated here?