### PR TITLE
Update FESTER_URL to new ingest endpoint

### DIFF
--- a/apps/services-team-value-files/test-bucketeer.yaml
+++ b/apps/services-team-value-files/test-bucketeer.yaml
@@ -193,7 +193,7 @@ configmap:
     FEATURE_FLAGS: "https://raw.githubusercontent.com/UCLALibrary/ansible_uclalib_plays/master/bucketeer/files/bucketeer-features-on.conf"
     LARGE_IMAGE_BUCKETEER: "http://test-large-bucketeer.test-large-bucketeer.svc.cluster.local"
     BATCH_CALLBACK_URL: "http://test-bucketeer.test-bucketeer.svc.cluster.local:80/batch/jobs/{}/{}/"
-    FESTER_URL: "http://test-iiif.library.ucla.edu/fester"
+    FESTER_URL: "http://test.ingest.iiif.library.ucla.edu"
 #---------------------------------------------
 
 


### PR DESCRIPTION
@cachemeoutside I'm unsure about lines 194, 195 because it looks like those are using internal routing, but it looks like at some point we moved from `test-iiif` to `test.iiif` and we neglected to update this file (i.e., we deployed straight to prod).